### PR TITLE
Add demo UI and API tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+test-results/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # vibe-test-saas
+
+This repository contains demo UI and API tests using [Playwright](https://playwright.dev/) and [PactumJS](https://pactumjs.github.io/).
+
+## Setup
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+## Running Tests
+
+- **UI Tests**: `npm run test:ui`
+- **API Tests**: `npm run test:api`
+- **All Tests**: `npm test`
+
+The UI test opens `https://example.com` and verifies the page title. The API test fetches a sample post from `jsonplaceholder.typicode.com` and checks the response.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "vibe-test-saas",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "npm run test:ui && npm run test:api",
+    "test:ui": "playwright test tests/ui.test.js",
+    "test:api": "mocha tests/api.test.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "@playwright/test": "^1.54.1",
+    "mocha": "^11.7.1",
+    "pactum": "^3.8.0",
+    "playwright": "^1.54.1"
+  }
+}

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -1,0 +1,27 @@
+const pactum = require('pactum');
+const { mock } = pactum;
+
+// Basic API test using PactumJS with a local mock server
+
+describe('local mock api', () => {
+  before(() => mock.start(3000));
+  after(() => mock.stop());
+
+  it('should return a mocked response', async () => {
+    mock.addInteraction({
+      request: {
+        method: 'GET',
+        path: '/posts/1'
+      },
+      response: {
+        status: 200,
+        body: { id: 1, title: 'Mock Post' }
+      }
+    });
+
+    await pactum.spec()
+      .get('http://localhost:3000/posts/1')
+      .expectStatus(200)
+      .expectJsonLike({ id: 1 });
+  });
+});

--- a/tests/example.html
+++ b/tests/example.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Example Domain</title>
+</head>
+<body>
+  <h1>Example Domain</h1>
+  <p>This is a local page for Playwright testing.</p>
+</body>
+</html>

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -1,0 +1,10 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+// Basic UI test to demonstrate Playwright using a local page
+
+test('local example page has correct title', async ({ page }) => {
+  const filePath = path.join(__dirname, 'example.html');
+  await page.goto('file://' + filePath);
+  await expect(page).toHaveTitle(/Example Domain/);
+});


### PR DESCRIPTION
## Summary
- add npm project with Playwright and PactumJS
- create local demo UI test and sample HTML page
- create API test using Pactum mock server
- update README with instructions
- ignore node modules and test-results

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a62d95190832fbf023f4fc5a8dded